### PR TITLE
Add .net10 support, remove dead code, rework how dlls are retrieved

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -56,6 +56,8 @@
             ConfigurationName: "Blazor",
             Extensions: ImmutableArray<RazorExtension>.Empty);
 
+        private RazorProjectEngine _declarationProjectEngine;
+
         public static unsafe Task InitAsync()
         {
             if (_baseCompilation != null) return Task.CompletedTask;
@@ -195,7 +197,8 @@
             Func<string, Task> updateStatusFunc)
         {
             // The first phase won't include any metadata references for component discovery. This mirrors what the build does.
-            var projectEngine = this.CreateRazorProjectEngine(Array.Empty<MetadataReference>());
+            _declarationProjectEngine ??= this.CreateRazorProjectEngine(Array.Empty<MetadataReference>());
+            var projectEngine = _declarationProjectEngine;
 
             // Result of generating declarations
             var declarations = new CompileToCSharpResult[codeFiles.Count];

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -131,6 +131,32 @@
             return result;
         }
 
+        // Compiles to a Roslyn compilation reference without emitting a PE image.
+        // Used for the declaration (phase 1) pass where we only need component type info.
+        private static (CompileToCSharpResult error, MetadataReference metadataRef) CompileToMetadataReference(
+            IReadOnlyList<CompileToCSharpResult> cSharpResults)
+        {
+            if (cSharpResults.Any(r => r.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error)))
+            {
+                return (new CompileToCSharpResult { Diagnostics = cSharpResults.SelectMany(r => r.Diagnostics).ToList() }, null);
+            }
+
+            var syntaxTrees = new SyntaxTree[cSharpResults.Count];
+            for (var i = 0; i < cSharpResults.Count; i++)
+            {
+                syntaxTrees[i] = CSharpSyntaxTree.ParseText(cSharpResults[i].Code, _cSharpParseOptions, cSharpResults[i].FilePath);
+            }
+
+            var compilation = _baseCompilation.AddSyntaxTrees(syntaxTrees);
+            var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).ToList();
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                return (new CompileToCSharpResult { Diagnostics = diagnostics.Select(CompilationDiagnostic.FromCSharpDiagnostic).ToList() }, null);
+            }
+
+            return (null, compilation.ToMetadataReference());
+        }
+
         private static CompileToAssemblyResult CompileToAssembly(IReadOnlyList<CompileToCSharpResult> cSharpResults)
         {
             if (cSharpResults.Any(r => r.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error)))
@@ -160,7 +186,7 @@
 
             if (result.Diagnostics.All(x => x.Severity != DiagnosticSeverity.Error))
             {
-                using var peStream = new MemoryStream();
+                using var peStream = new MemoryStream(capacity: 512 * 1024);
                 finalCompilation.Emit(peStream);
 
                 result.AssemblyBytes = peStream.ToArray();
@@ -234,15 +260,15 @@
                 index++;
             }
 
-            // Result of doing 'temp' compilation
-            var tempAssembly = CompileToAssembly(declarations);
-            if (tempAssembly.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            // Result of doing 'temp' compilation (no emit needed — only used as a metadata reference)
+            var (tempErrors, tempRef) = CompileToMetadataReference(declarations);
+            if (tempErrors != null)
             {
-                return [new CompileToCSharpResult { Diagnostics = tempAssembly.Diagnostics }];
+                return [tempErrors];
             }
 
             // Add the 'temp' compilation as a metadata reference
-            var references = new List<MetadataReference>(_baseCompilation.References) { tempAssembly.Compilation.ToMetadataReference() };
+            var references = new List<MetadataReference>(_baseCompilation.References) { tempRef };
             projectEngine = CreateRazorProjectEngine(references);
 
             await (updateStatusFunc?.Invoke("Preparing Project") ?? Task.CompletedTask);

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -58,6 +58,8 @@
 
         public static unsafe Task InitAsync()
         {
+            if (_baseCompilation != null) return Task.CompletedTask;
+
             var basicReferenceAssemblyRoots = new[]
             {
                 typeof(Console).Assembly, // System.Console

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -8,7 +8,6 @@
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Json;
-    using System.Reflection;
     using System.Reflection.Metadata;
     using System.Runtime;
     using System.Text;

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -49,6 +49,9 @@
         private static CSharpCompilation _baseCompilation;
         private static CSharpParseOptions _cSharpParseOptions;
 
+        private int _lastCodeHash;
+        private CompileToAssemblyResult _cachedResult;
+
         private readonly RazorProjectFileSystem fileSystem = new VirtualRazorProjectFileSystem();
         private readonly RazorConfiguration configuration = new(
             RazorLanguageVersion.Latest,
@@ -123,12 +126,32 @@
         {
             ArgumentNullException.ThrowIfNull(codeFiles);
 
+            var codeHash = ComputeCodeHash(codeFiles);
+            if (_cachedResult != null && _lastCodeHash == codeHash)
+            {
+                return _cachedResult;
+            }
+
             var cSharpResults = await this.CompileToCSharpAsync(codeFiles, updateStatusFunc);
 
             await (updateStatusFunc?.Invoke("Compiling Assembly") ?? Task.CompletedTask);
             var result = CompileToAssembly(cSharpResults);
 
+            _lastCodeHash = codeHash;
+            _cachedResult = result;
+
             return result;
+        }
+
+        private static int ComputeCodeHash(ICollection<CodeFile> codeFiles)
+        {
+            var hash = new HashCode();
+            foreach (var file in codeFiles)
+            {
+                hash.Add(file.Path);
+                hash.Add(file.Content);
+            }
+            return hash.ToHashCode();
         }
 
         // Compiles to a Roslyn compilation reference without emitting a PE image.
@@ -206,7 +229,10 @@
                 filePath = '/' + filePath;
             }
 
-            fileContent = fileContent.Replace("\r", string.Empty);
+            if (fileContent.Contains('\r'))
+            {
+                fileContent = fileContent.Replace("\r", string.Empty);
+            }
 
             return new VirtualProjectItem(
                 WorkingDirectory,

--- a/src/Try.Core/CompilationService.cs
+++ b/src/Try.Core/CompilationService.cs
@@ -8,6 +8,8 @@
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Json;
+    using System.Reflection;
+    using System.Reflection.Metadata;
     using System.Runtime;
     using System.Text;
     using System.Threading.Tasks;
@@ -54,7 +56,7 @@
             ConfigurationName: "Blazor",
             Extensions: ImmutableArray<RazorExtension>.Empty);
 
-        public static async Task InitAsync(Func<IReadOnlyCollection<string>, ValueTask<IReadOnlyList<byte[]>>> getReferencedDllsBytesFunc)
+        public static unsafe Task InitAsync()
         {
             var basicReferenceAssemblyRoots = new[]
             {
@@ -71,22 +73,32 @@
                 typeof(WebAssemblyHostBuilder).Assembly, // Microsoft.AspNetCore.Components.WebAssembly
                 typeof(FluentValidation.AbstractValidator<>).Assembly,
             };
-            var assemblyNames = await getReferencedDllsBytesFunc(basicReferenceAssemblyRoots
-                .SelectMany(assembly => assembly.GetReferencedAssemblies().Concat(
-                [
-                    assembly.GetName()
-                ]))
-                .Select(assemblyName => assemblyName.Name)
-                .ToHashSet());
 
-            var basicReferenceAssemblies = assemblyNames
-                .Select(peImage => MetadataReference.CreateFromImage(peImage, MetadataReferenceProperties.Assembly))
-                .ToList();
+            var assemblyNames = basicReferenceAssemblyRoots
+                .SelectMany(assembly => assembly.GetReferencedAssemblies().Concat([assembly.GetName()]))
+                .Select(assemblyName => assemblyName.Name!)
+                .ToHashSet();
+
+            // netstandard facade is needed for libraries that target netstandard2.0
+            assemblyNames.Add("netstandard");
+
+            var loadedByName = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic && a.GetName().Name != null)
+                .ToDictionary(a => a.GetName().Name!, StringComparer.OrdinalIgnoreCase);
+
+            var references = new List<MetadataReference>();
+            foreach (var name in assemblyNames)
+            {
+                if (!loadedByName.TryGetValue(name, out var assembly)) continue;
+                if (!assembly.TryGetRawMetadata(out byte* blob, out int length)) continue;
+                var moduleMetadata = ModuleMetadata.CreateFromMetadata((IntPtr)blob, length);
+                references.Add(AssemblyMetadata.Create(moduleMetadata).GetReference());
+            }
 
             _baseCompilation = CSharpCompilation.Create(
                 DefaultRootNamespace,
                 Array.Empty<SyntaxTree>(),
-                basicReferenceAssemblies,
+                references,
                 new CSharpCompilationOptions(
                     OutputKind.DynamicallyLinkedLibrary,
                     optimizationLevel: OptimizationLevel.Release,
@@ -99,6 +111,7 @@
                     }));
 
             _cSharpParseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+            return Task.CompletedTask;
         }
 
         public async Task<CompileToAssemblyResult> CompileToAssemblyAsync(

--- a/src/Try.Core/Try.Core.csproj
+++ b/src/Try.Core/Try.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.CodeAnalysis.Razor.Test</AssemblyName>
     <KeyOriginatorFile>$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\snk\AspNetCore.snk</KeyOriginatorFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Try.Tests/SnippetsServiceTests.cs
+++ b/src/Try.Tests/SnippetsServiceTests.cs
@@ -42,7 +42,7 @@ namespace Tests
         [Ignore("Investigate failure")]
         public async Task TestGet()
         {
-            var snippetService = new SnippetsService(snippetsOptions, new System.Net.Http.HttpClient(), new MockNavigationManager());
+            var snippetService = new SnippetsService(snippetsOptions, new HttpClient(), new MockNavigationManager());
             var codeFiles = await snippetService.GetSnippetContentAsync("2021020540572059");
             Assert.That(codeFiles, Is.Not.Null);
         }
@@ -51,7 +51,7 @@ namespace Tests
         [Ignore("Investigate failure")]
         public async Task TestPut()
         {
-            var snippetService = new SnippetsService(snippetsOptions, new System.Net.Http.HttpClient(), new MockNavigationManager());
+            var snippetService = new SnippetsService(snippetsOptions, new HttpClient(), new MockNavigationManager());
             var id = await snippetService.SaveSnippetAsync(codeFiles);
             Assert.That(id, Is.Not.Null);
             Console.WriteLine(id);

--- a/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
+++ b/src/TryMudBlazor.Client/Components/SaveSnippetPopup.razor.cs
@@ -75,7 +75,7 @@ namespace TryMudBlazor.Client.Components
             }
         }
 
-        private async void OnClose()
+        private async Task OnClose()
         {
             Loading = false;
             SnippetLink = string.Empty;

--- a/src/TryMudBlazor.Client/Models/TryConstants.cs
+++ b/src/TryMudBlazor.Client/Models/TryConstants.cs
@@ -19,7 +19,6 @@
 
         public static class CodeExecution
         {
-            public const string GetCompilationDlls = "Try.CodeExecution.getCompilationDlls";
             public const string UpdateUserComponentsDll = "Try.CodeExecution.updateUserComponentsDll";
         }
     }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -204,7 +204,7 @@
             if (compilationResult?.AssemblyBytes?.Length > 0)
             {
                 // Make sure the DLL is updated before reloading the user page
-                await this.JsRuntime.InvokeVoidAsync(Try.CodeExecution.UpdateUserComponentsDll, compilationResult.AssemblyBytes);
+                this.JsRuntime.InvokeVoid(Try.CodeExecution.UpdateUserComponentsDll, compilationResult.AssemblyBytes);
 
                 // TODO: Add error page in iframe
                 this.JsRuntime.InvokeVoid(Try.ReloadIframe, "user-page-window", MainUserPagePath);
@@ -290,10 +290,9 @@
             await JsRuntime.InvokeVoidAsync("updateIframeTheme");
         }
 
-        private async Task ClearCache()
+        private void ClearCache()
         {
-            await JsRuntime.InvokeVoidAsync("Try.clearCache");
-            NavigationManager.NavigateTo(NavigationManager.BaseUri, true);
+            NavigationManager.NavigateTo(NavigationManager.BaseUri, forceLoad: true);
         }
     }
 }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -280,11 +280,11 @@
             return Task.Delay(10); // Ensure rendering has time to be called
         }
 
-        private async void UpdateTheme()
+        private async Task UpdateTheme()
         {
             await LayoutService.ToggleDarkMode();
             string theme = LayoutService.IsDarkMode ? "vs-dark" : "default";
-            this.JsRuntime.InvokeVoid(Try.Editor.SetTheme, theme);
+            await JsRuntime.InvokeVoidAsync(Try.Editor.SetTheme, theme);
             // LayoutService calls StateHasChanged, we need the updated <style> tags for updateIframeTheme to work
             await Task.Yield();
             await JsRuntime.InvokeVoidAsync("updateIframeTheme");

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -163,7 +163,7 @@
             this.Loading = true;
             this.LoaderText = "Processing";
 
-            await Task.Delay(10); // Ensure rendering has time to be called
+            await Task.Yield();
 
             CompileToAssemblyResult compilationResult = null;
             CodeFile mainComponent = null;
@@ -271,13 +271,13 @@
             this.activeCodeFile.Content = this.CodeEditorComponent.GetCode();
         }
 
-        private Task UpdateLoaderTextAsync(string loaderText)
+        private async Task UpdateLoaderTextAsync(string loaderText)
         {
             this.LoaderText = loaderText;
 
             this.StateHasChanged();
 
-            return Task.Delay(10); // Ensure rendering has time to be called
+            await Task.Yield();
         }
 
         private async Task UpdateTheme()

--- a/src/TryMudBlazor.Client/Shared/MainLayout.razor.cs
+++ b/src/TryMudBlazor.Client/Shared/MainLayout.razor.cs
@@ -3,11 +3,9 @@
     using System;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
-    using Microsoft.JSInterop;
     using MudBlazor;
     using Services;
     using Try.Core;
-    using static TryMudBlazor.Client.Models.Try;
 
     public partial class MainLayout : LayoutComponentBase, IDisposable
     {
@@ -15,9 +13,6 @@
 
         [Inject]
         private LayoutService LayoutService { get; set; }
-
-        [Inject]
-        private IJSRuntime JsRuntime { get; set; }
 
         protected override void OnInitialized()
         {
@@ -32,14 +27,9 @@
             if (firstRender)
             {
                 await ApplyUserPreferences();
-                await CompilationService.InitAsync(GetReferenceAssembliesStreamsAsync);
+                await CompilationService.InitAsync();
                 StateHasChanged();
             }
-        }
-
-        private ValueTask<IReadOnlyList<byte[]>> GetReferenceAssembliesStreamsAsync(IReadOnlyCollection<string> referenceAssemblyNames)
-        {
-            return JsRuntime.InvokeAsync<IReadOnlyList<byte[]>>(CodeExecution.GetCompilationDlls, new List<string>(referenceAssemblyNames) { "netstandard" });
         }
 
         private async Task ApplyUserPreferences()

--- a/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
+++ b/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
+++ b/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PublishTrimmed>false</PublishTrimmed>
-    <WasmEnableWebcil>false</WasmEnableWebcil>
+    <WasmEnableWebcil>true</WasmEnableWebcil>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -193,6 +193,7 @@ window.Try.Editor = window.Try.Editor || (function () {
 
 window.Try.CodeExecution = window.Try.CodeExecution || (function () {
     const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error has occurred. Please try again later or contact the team.';
+    const USER_COMPONENTS_DLL_STORAGE_KEY = 'TryMudBlazor.UserComponentsDllBase64';
 
     function putInCacheStorage(cache, fileName, fileBytes, contentType) {
         const cachedResponse = new Response(
@@ -219,43 +220,66 @@ window.Try.CodeExecution = window.Try.CodeExecution || (function () {
         return bytes;
     }
 
+    function convertBytesToBase64String(bytes) {
+        let binaryString = '';
+        for (let i = 0; i < bytes.length; i++) {
+            binaryString += String.fromCharCode(bytes[i]);
+        }
+
+        return window.btoa(binaryString);
+    }
+
     return {
         getCompilationDlls: async function (dllNames) {
-            const cache = await caches.open(CACHE_NAME);
-            const keys = await cache.keys();
-            const dllsData = [];
-            await Promise.all(dllNames.map(async (dll) => {
-                // Requires WasmFingerprintAssets to be enabled
-                const pattern = new RegExp(`${dll}.[^\\.]*\\.dll`, 'i');
-                const dllKey = keys.find(x => pattern.test(x.url)).url.substring(window.location.origin.length);
-                const response = await cache.match(dllKey);
-                const bytes = new Uint8Array(await response.arrayBuffer());
-                dllsData.push(bytes);
-            }));
+            const config = window.Blazor && Blazor.runtime && Blazor.runtime.getConfig ? Blazor.runtime.getConfig() : null;
+            const resources = config && config.resources ? config.resources : {};
 
-            return dllsData;
+            const getAssemblyAssetName = (simpleName) => {
+                const virtualName = `${simpleName}.dll`;
+                const arrayGroups = [resources.coreAssembly, resources.assembly].filter(Array.isArray);
+                for (const group of arrayGroups) {
+                    const asset = group.find(x => x && (x.virtualPath === virtualName || x.name === virtualName));
+                    if (asset && asset.name) {
+                        return asset.name;
+                    }
+                }
+                throw new Error(`.NET 10 boot config assembly asset not found for '${virtualName}'`);
+            };
+
+            const fetchDllBytes = async (dllName) => {
+                const assetName = getAssemblyAssetName(dllName);
+                const urls = [
+                    `_framework/${assetName}`,
+                    `_framework/${dllName}.dll`
+                ];
+
+                for (const url of urls) {
+                    const response = await fetch(url, { cache: 'force-cache' });
+                    if (response && response.ok) {
+                        return new Uint8Array(await response.arrayBuffer());
+                    }
+                }
+
+                throw new Error(`Failed to fetch compilation DLL '${dllName}' (resolved '${assetName}')`);
+            };
+
+            return Promise.all(dllNames.map(dll => fetchDllBytes(dll)));
         },
 
         updateUserComponentsDll: async function (fileContent) {
             if (!fileContent) {
                 return;
             }
-
-            const cache = await caches.open(CACHE_NAME);
-
-            const cacheKeys = await cache.keys();
-            // Requires WasmFingerprintAssets to be enabled
-            const userComponentsDllCacheKey = cacheKeys.find(x => /Try\.UserComponents\.[^/]*\.dll/.test(x.url));
-            if (!userComponentsDllCacheKey || !userComponentsDllCacheKey.url) {
-                alert(UNEXPECTED_ERROR_MESSAGE);
-                return;
-            }
-
-            const dllPath = userComponentsDllCacheKey.url.substring(window.location.origin.length);
             fileContent = typeof fileContent === 'number' ? BINDING.conv_string(fileContent) : fileContent // tranfering raw pointer to the memory of the mono string
             const dllBytes = typeof fileContent === 'string' ? convertBase64StringToBytes(fileContent) : fileContent;
+            const dllBase64 = convertBytesToBase64String(dllBytes);
 
-            await putInCacheStorage(cache, dllPath, dllBytes);
+            try {
+                window.sessionStorage.setItem(USER_COMPONENTS_DLL_STORAGE_KEY, dllBase64);
+            } catch (error) {
+                console.error('Failed to store compiled user components DLL', error);
+                alert(UNEXPECTED_ERROR_MESSAGE);
+            }
         }
     };
 }());

--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -230,42 +230,6 @@ window.Try.CodeExecution = window.Try.CodeExecution || (function () {
     }
 
     return {
-        getCompilationDlls: async function (dllNames) {
-            const config = window.Blazor && Blazor.runtime && Blazor.runtime.getConfig ? Blazor.runtime.getConfig() : null;
-            const resources = config && config.resources ? config.resources : {};
-
-            const getAssemblyAssetName = (simpleName) => {
-                const virtualName = `${simpleName}.dll`;
-                const arrayGroups = [resources.coreAssembly, resources.assembly].filter(Array.isArray);
-                for (const group of arrayGroups) {
-                    const asset = group.find(x => x && (x.virtualPath === virtualName || x.name === virtualName));
-                    if (asset && asset.name) {
-                        return asset.name;
-                    }
-                }
-                throw new Error(`.NET 10 boot config assembly asset not found for '${virtualName}'`);
-            };
-
-            const fetchDllBytes = async (dllName) => {
-                const assetName = getAssemblyAssetName(dllName);
-                const urls = [
-                    `_framework/${assetName}`,
-                    `_framework/${dllName}.dll`
-                ];
-
-                for (const url of urls) {
-                    const response = await fetch(url, { cache: 'force-cache' });
-                    if (response && response.ok) {
-                        return new Uint8Array(await response.arrayBuffer());
-                    }
-                }
-
-                throw new Error(`Failed to fetch compilation DLL '${dllName}' (resolved '${assetName}')`);
-            };
-
-            return Promise.all(dllNames.map(dll => fetchDllBytes(dll)));
-        },
-
         updateUserComponentsDll: async function (fileContent) {
             if (!fileContent) {
                 return;

--- a/src/TryMudBlazor.Client/wwwroot/editor/main.js
+++ b/src/TryMudBlazor.Client/wwwroot/editor/main.js
@@ -3,7 +3,6 @@ require.config({ paths: { 'vs': 'lib/monaco-editor/min/vs' } });
 let _dotNetInstance;
 
 const throttleLastTimeFuncNameMappings = {};
-const CACHE_NAME = 'dotnet-resources-/';
 
 function registerLangugageProvider(language) {
     monaco.languages.registerCompletionItemProvider(language, {
@@ -99,20 +98,6 @@ window.Try = {
             setTimeout(() => iFrame.src = newSrc);
         }
     },
-    clearCache: async function () {
-        const cacheName = CACHE_NAME;
-        try {
-            const cache = await caches.open(cacheName);
-            const keys = await cache.keys();
-
-            await Promise.all(keys.map(key => {
-                return cache.delete(key);
-            }));
-            console.log(`Cache '${cacheName}' has been cleared.`);
-        } catch (error) {
-            console.error('Error clearing cache:', error);
-        }
-    },
     dispose: function () {
         _dotNetInstance = null;
         window.removeEventListener('keydown', onKeyDown);
@@ -195,48 +180,24 @@ window.Try.CodeExecution = window.Try.CodeExecution || (function () {
     const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error has occurred. Please try again later or contact the team.';
     const USER_COMPONENTS_DLL_STORAGE_KEY = 'TryMudBlazor.UserComponentsDllBase64';
 
-    function putInCacheStorage(cache, fileName, fileBytes, contentType) {
-        const cachedResponse = new Response(
-            new Blob([fileBytes]),
-            {
-                headers: {
-                    'Content-Type': contentType || 'application/octet-stream',
-                    'Content-Length': fileBytes.length.toString()
-                }
-            });
-
-        return cache.put(fileName, cachedResponse);
-    }
-
-    function convertBase64StringToBytes(base64String) {
-        const binaryString = window.atob(base64String);
-
-        const bytesCount = binaryString.length;
-        const bytes = new Uint8Array(bytesCount);
-        for (let i = 0; i < bytesCount; i++) {
-            bytes[i] = binaryString.charCodeAt(i);
-        }
-
-        return bytes;
-    }
-
-    function convertBytesToBase64String(bytes) {
-        let binaryString = '';
-        for (let i = 0; i < bytes.length; i++) {
-            binaryString += String.fromCharCode(bytes[i]);
-        }
-
-        return window.btoa(binaryString);
-    }
-
     return {
-        updateUserComponentsDll: async function (fileContent) {
-            if (!fileContent) {
-                return;
+        updateUserComponentsDll: function (dllData) {
+            if (!dllData) return;
+
+            // .NET byte[] arrives as a Uint8Array via the runtime's byte-array interop optimization.
+            // A plain string means the caller passed a pre-encoded base64 constant (e.g. DefaultUserComponentsAssemblyBytes).
+            let dllBase64;
+            if (typeof dllData === 'string') {
+                dllBase64 = dllData;
+            } else {
+                // Uint8Array → base64, processed in chunks to avoid call-stack overflow on large arrays.
+                let binary = '';
+                const chunk = 8192;
+                for (let i = 0; i < dllData.length; i += chunk) {
+                    binary += String.fromCharCode(...dllData.subarray(i, i + chunk));
+                }
+                dllBase64 = btoa(binary);
             }
-            fileContent = typeof fileContent === 'number' ? BINDING.conv_string(fileContent) : fileContent // tranfering raw pointer to the memory of the mono string
-            const dllBytes = typeof fileContent === 'string' ? convertBase64StringToBytes(fileContent) : fileContent;
-            const dllBase64 = convertBytesToBase64String(dllBytes);
 
             try {
                 window.sessionStorage.setItem(USER_COMPONENTS_DLL_STORAGE_KEY, dllBase64);

--- a/src/TryMudBlazor.Client/wwwroot/index.html
+++ b/src/TryMudBlazor.Client/wwwroot/index.html
@@ -63,13 +63,9 @@
     <script type="text/javascript">
         const userComponentsDllStorageKey = 'TryMudBlazor.UserComponentsDllBase64';
 
-        function base64ToBytes(base64String) {
-            const binaryString = window.atob(base64String);
-            const bytes = new Uint8Array(binaryString.length);
-            for (let i = 0; i < binaryString.length; i++) {
-                bytes[i] = binaryString.charCodeAt(i);
-            }
-            return bytes;
+        function base64ToBytes(base64) {
+            const binary = atob(base64);
+            return Uint8Array.from(binary, c => c.charCodeAt(0));
         }
 
         Blazor.start({

--- a/src/TryMudBlazor.Client/wwwroot/index.html
+++ b/src/TryMudBlazor.Client/wwwroot/index.html
@@ -69,59 +69,31 @@
             for (let i = 0; i < binaryString.length; i++) {
                 bytes[i] = binaryString.charCodeAt(i);
             }
-
             return bytes;
         }
 
-        async function resolveUserComponentsAssemblyAssetName() {
-            const response = await fetch('_framework/dotnet.js', { cache: 'no-cache' });
-            const script = await response.text();
-            const startToken = '/*json-start*/';
-            const endToken = '/*json-end*/';
-            const start = script.indexOf(startToken);
-            const end = script.indexOf(endToken);
+        Blazor.start({
+            loadBootResource: function (type, name, defaultUri) {
+                if (!window.frameElement || window.location.pathname !== '/__main') {
+                    return defaultUri;
+                }
+                if (type !== 'assembly' || !name.startsWith('Try.UserComponents.')) {
+                    return defaultUri;
+                }
 
-            if (start < 0 || end <= start) {
-                return null;
-            }
+                const base64Dll = window.sessionStorage.getItem(userComponentsDllStorageKey);
+                if (!base64Dll) {
+                    return defaultUri;
+                }
 
-            const configJson = script.substring(start + startToken.length, end);
-            const config = JSON.parse(configJson);
-            const resources = config && config.resources ? config.resources : {};
-            const assemblies = []
-                .concat(Array.isArray(resources.coreAssembly) ? resources.coreAssembly : [])
-                .concat(Array.isArray(resources.assembly) ? resources.assembly : []);
-
-            const userComponentsAsset = assemblies.find(x => x && x.virtualPath === 'Try.UserComponents.dll');
-            return userComponentsAsset && userComponentsAsset.name ? userComponentsAsset.name : null;
-        }
-
-        resolveUserComponentsAssemblyAssetName()
-            .then(function (userComponentsAssemblyAssetName) {
-                return Blazor.start({
-                    loadBootResource: function (type, name, defaultUri) {
-                        if (!window.frameElement || window.location.pathname !== '/__main') {
-                            return defaultUri;
-                        }
-                        if (type !== 'assembly' || name !== userComponentsAssemblyAssetName) {
-                            return defaultUri;
-                        }
-
-                        const base64Dll = window.sessionStorage.getItem(userComponentsDllStorageKey);
-                        if (!base64Dll) {
-                            return defaultUri;
-                        }
-
-                        const dllBytes = base64ToBytes(base64Dll);
-                        return Promise.resolve(new Response(dllBytes, {
-                            headers: {
-                                'Content-Type': 'application/octet-stream'
-                            }
-                        }));
+                const dllBytes = base64ToBytes(base64Dll);
+                return Promise.resolve(new Response(dllBytes, {
+                    headers: {
+                        'Content-Type': 'application/octet-stream'
                     }
-                });
-            })
-            .catch(error => console.error(error));
+                }));
+            }
+        }).catch(error => console.error(error));
 
         function updateIframeTheme() {
             const mudblazorTheme = parent.document.querySelector('.mud-theme-provider') || parent.document.getElementsByTagName('style')[3];

--- a/src/TryMudBlazor.Client/wwwroot/index.html
+++ b/src/TryMudBlazor.Client/wwwroot/index.html
@@ -57,10 +57,72 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js?v=#{CACHE_TOKEN}#"></script>
     <script src="editor/main.js?v=#{CACHE_TOKEN}#"></script>
     <script type="text/javascript">
+        const userComponentsDllStorageKey = 'TryMudBlazor.UserComponentsDllBase64';
+
+        function base64ToBytes(base64String) {
+            const binaryString = window.atob(base64String);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i);
+            }
+
+            return bytes;
+        }
+
+        async function resolveUserComponentsAssemblyAssetName() {
+            const response = await fetch('_framework/dotnet.js', { cache: 'no-cache' });
+            const script = await response.text();
+            const startToken = '/*json-start*/';
+            const endToken = '/*json-end*/';
+            const start = script.indexOf(startToken);
+            const end = script.indexOf(endToken);
+
+            if (start < 0 || end <= start) {
+                return null;
+            }
+
+            const configJson = script.substring(start + startToken.length, end);
+            const config = JSON.parse(configJson);
+            const resources = config && config.resources ? config.resources : {};
+            const assemblies = []
+                .concat(Array.isArray(resources.coreAssembly) ? resources.coreAssembly : [])
+                .concat(Array.isArray(resources.assembly) ? resources.assembly : []);
+
+            const userComponentsAsset = assemblies.find(x => x && x.virtualPath === 'Try.UserComponents.dll');
+            return userComponentsAsset && userComponentsAsset.name ? userComponentsAsset.name : null;
+        }
+
+        resolveUserComponentsAssemblyAssetName()
+            .then(function (userComponentsAssemblyAssetName) {
+                return Blazor.start({
+                    loadBootResource: function (type, name, defaultUri) {
+                        if (!window.frameElement || window.location.pathname !== '/__main') {
+                            return defaultUri;
+                        }
+                        if (type !== 'assembly' || name !== userComponentsAssemblyAssetName) {
+                            return defaultUri;
+                        }
+
+                        const base64Dll = window.sessionStorage.getItem(userComponentsDllStorageKey);
+                        if (!base64Dll) {
+                            return defaultUri;
+                        }
+
+                        const dllBytes = base64ToBytes(base64Dll);
+                        return Promise.resolve(new Response(dllBytes, {
+                            headers: {
+                                'Content-Type': 'application/octet-stream'
+                            }
+                        }));
+                    }
+                });
+            })
+            .catch(error => console.error(error));
+
         function updateIframeTheme() {
             const mudblazorTheme = parent.document.querySelector('.mud-theme-provider') || parent.document.getElementsByTagName('style')[3];
 

--- a/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
+++ b/src/TryMudBlazor.Server/TryMudBlazor.Server.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UserComponents/Try.UserComponents.csproj
+++ b/src/UserComponents/Try.UserComponents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 .NET 10 broke the `dotnet-resources-/` cache that we relied on to fetch reference assemblies for Roslyn compilation. There is no longer a blazor.boot.json, the boot config is now inlined inside `dotnet.js` https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly/bundle-caching-and-integrity-check-failures?view=aspnetcore-10.0

First I tried this approach (commit bb64f7794): fetched `_framework/dotnet.js` at startup, parsed its embedded JSON to resolve fingerprinted assembly filenames (e.g. MudBlazor.abc123.dll), then fetched each DLL over HTTP to build Roslyn
`MetadataReference` objects. Complex and slow.

New approach: uses `Assembly.TryGetRawMetadata()` to read PE bytes directly from assemblies already loaded in the WASM process, zero HTTP requests.

Dead code removed: `getCompilationDlls`, `putInCacheStorage`, `clearCache`, `convertBase64StringToBytes`,
`convertBytesToBase64String`, `CACHE_NAME`, etc all gone.