### PR TITLE
Add Renovate config, replace Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "nuget"
-    directory: "/src/"
-    target-branch: "main"
-    schedule:
-      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "commitMessagePrefix": "Build: ",
+  "packageRules": [
+    {
+      "description": "Group non-major NuGet updates into a single PR",
+      "matchManagers": ["nuget"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "NuGet packages (non-major)"
+    },
+    {
+      "description": "Group GitHub Actions updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Framework-versioned packages track the TFM in Directory.Build.props; majors belong to a TFM upgrade, so require dependency dashboard approval",
+      "matchPackageNames": ["Microsoft.AspNetCore.*", "System.Net.Http.Json"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "The Roslyn/Razor compiler toolchain powers in-browser compilation and its pinned prerelease versions must move in lockstep (see #190); group and require dependency dashboard approval",
+      "matchPackageNames": [
+        "Microsoft.CodeAnalysis.*",
+        "Microsoft.Net.Compilers.Razor.Toolset",
+        "Microsoft.DotNet.Arcade.Sdk"
+      ],
+      "groupName": "Razor compiler toolchain",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "MudBlazor floats at * so the playground always runs the latest release; nothing for Renovate to manage",
+      "matchPackageNames": ["MudBlazor"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `renovate.json` and removes `.github/dependabot.yml`, switching dependency updates from Dependabot to Renovate. Renovate is already installed on the repo (it opened the onboarding PR #183) — merging this activates it with the config below, and the onboarding PR closes automatically. The open Dependabot bump PRs (#193–#197) can then be closed; Renovate will re-raise them per the rules here.

- **Base**: `config:recommended`, `dependencies` label, and `Build: ` commit prefix — matching the main MudBlazor repo's Renovate config and this repo's commit style.
- **Non-major NuGet updates grouped into a single PR** (same convention as ThemeManager) — replaces the one-PR-per-package noise.
- **GitHub Actions updates grouped into a single PR** — Dependabot wasn't covering the workflow files at all.
- **Framework-versioned majors gated**: `Microsoft.AspNetCore.*` / `System.Net.Http.Json` majors track the TFM in `Directory.Build.props` and require dependency dashboard approval; minor/patch (e.g. 10.0.0 → 10.0.3) flow through normally.
- **Razor compiler toolchain gated**: `Microsoft.CodeAnalysis.*`, `Microsoft.Net.Compilers.Razor.Toolset`, and `Microsoft.DotNet.Arcade.Sdk` are lockstep prerelease pins powering in-browser compilation and historically only move during deliberate upgrades (#190). They're grouped into one PR that requires dashboard approval, so Renovate won't push preview bumps on its own.
- **MudBlazor disabled**: it floats at `*` by design so the playground always runs the latest release — nothing for Renovate to manage.