### PR TITLE
Show TryMudBlazor commit version in the playground status bar

### DIFF
--- a/src/TryMudBlazor.Client/Pages/Index/Index.razor
+++ b/src/TryMudBlazor.Client/Pages/Index/Index.razor
@@ -1,5 +1,4 @@
 ﻿@page "/"
-@using System.Reflection
 
 <MudLayout Class="try-mudblazor-index">
     <MudAppBar Color="Color.Transparent" Fixed="false" Elevation="0">
@@ -144,12 +143,6 @@
                         <li>
                             <MudLink Typo="Typo.body2" Href="https://github.com/MudBlazor/TryMudBlazor">Source Code</MudLink>
                         </li>
-                        @if (CommitSha is not null)
-                        {
-                            <li>
-                                <MudLink Typo="Typo.body2" Href="@($"https://github.com/MudBlazor/TryMudBlazor/commit/{CommitSha}")" Target="_blank">Version @CommitSha[..7]</MudLink>
-                            </li>
-                        }
                     </ul>
                 </MudItem>
             </MudGrid>
@@ -158,12 +151,6 @@
     </MudMainContent>
 </MudLayout>
 
-@code {
-    string Version { get { var v = typeof(MudText).Assembly.GetName().Version; return $"v{v.Major}.{v.Minor}.{v.Build}"; } }
-
-    // The SDK's built-in Source Link appends "+{commit sha}" to the informational version.
-    // It's absent when building without a git repository, in which case we hide the link.
-    static string CommitSha { get; } = Assembly.GetExecutingAssembly()
-        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-        ?.InformationalVersion.Split('+') is [_, { Length: 40 } sha] ? sha : null;
+@code { 
+    string Version { get { var v = typeof(MudText).Assembly.GetName().Version; return $"v{v.Major}.{v.Minor}.{v.Build}"; } } 
 }

--- a/src/TryMudBlazor.Client/Pages/Index/Index.razor
+++ b/src/TryMudBlazor.Client/Pages/Index/Index.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@using System.Reflection
 
 <MudLayout Class="try-mudblazor-index">
     <MudAppBar Color="Color.Transparent" Fixed="false" Elevation="0">
@@ -143,6 +144,12 @@
                         <li>
                             <MudLink Typo="Typo.body2" Href="https://github.com/MudBlazor/TryMudBlazor">Source Code</MudLink>
                         </li>
+                        @if (CommitSha is not null)
+                        {
+                            <li>
+                                <MudLink Typo="Typo.body2" Href="@($"https://github.com/MudBlazor/TryMudBlazor/commit/{CommitSha}")" Target="_blank">Version @CommitSha[..7]</MudLink>
+                            </li>
+                        }
                     </ul>
                 </MudItem>
             </MudGrid>
@@ -151,6 +158,12 @@
     </MudMainContent>
 </MudLayout>
 
-@code { 
-    string Version { get { var v = typeof(MudText).Assembly.GetName().Version; return $"v{v.Major}.{v.Minor}.{v.Build}"; } } 
+@code {
+    string Version { get { var v = typeof(MudText).Assembly.GetName().Version; return $"v{v.Major}.{v.Minor}.{v.Build}"; } }
+
+    // The SDK's built-in Source Link appends "+{commit sha}" to the informational version.
+    // It's absent when building without a git repository, in which case we hide the link.
+    static string CommitSha { get; } = Assembly.GetExecutingAssembly()
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?.InformationalVersion.Split('+') is [_, { Length: 40 } sha] ? sha : null;
 }

--- a/src/TryMudBlazor.Client/Pages/Repl.razor
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor
@@ -83,6 +83,10 @@
         <MudSpacer />
         <MudLink Typo="Typo.body2" Class="ml-10 version-info" Color="Color.Inherit" Href="https://dotnet.microsoft.com/download" Target="_blank">.net @Environment.Version.ToString()</MudLink>
         <MudLink Typo="Typo.body2" Class="ml-5 version-info" Color="Color.Inherit" Href="https://github.com/MudBlazor/MudBlazor/releases" Target="_blank">mudblazor @Version</MudLink>
+        @if (CommitSha is not null)
+        {
+            <MudLink Typo="Typo.body2" Class="ml-5 version-info" Color="Color.Inherit" Href="@($"https://github.com/MudBlazor/TryMudBlazor/commit/{CommitSha}")" Target="_blank">trymudblazor @CommitSha[..7]</MudLink>
+        }
     </MudAppBar>
 </div>
 @code {

--- a/src/TryMudBlazor.Client/Pages/Repl.razor
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor
@@ -85,7 +85,7 @@
         <MudLink Typo="Typo.body2" Class="ml-5 version-info" Color="Color.Inherit" Href="https://github.com/MudBlazor/MudBlazor/releases" Target="_blank">mudblazor @Version</MudLink>
         @if (CommitSha is not null)
         {
-            <MudLink Typo="Typo.body2" Class="ml-5 version-info" Color="Color.Inherit" Href="@($"https://github.com/MudBlazor/TryMudBlazor/commit/{CommitSha}")" Target="_blank">trymudblazor @CommitSha[..7]</MudLink>
+            <MudLink Typo="Typo.body2" Class="ml-5 version-info" Color="Color.Inherit" Href="@($"https://github.com/MudBlazor/TryMudBlazor/commit/{CommitSha}")" Target="_blank" title="TryMudBlazor commit">@CommitSha[..7]</MudLink>
         }
     </MudAppBar>
 </div>

--- a/src/TryMudBlazor.Client/Pages/Repl.razor.cs
+++ b/src/TryMudBlazor.Client/Pages/Repl.razor.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
     using Microsoft.CodeAnalysis;
@@ -82,6 +83,12 @@
                 return $"v{v.Major}.{v.Minor}.{v.Build}";
             }
         }
+
+        // The SDK's built-in Source Link appends "+{commit sha}" to the informational version.
+        // It's absent when building without a git repository, in which case we hide the link.
+        private static string CommitSha { get; } = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion.Split('+') is [_, { Length: 40 } sha] ? sha : null;
 
         [JSInvokable]
         public async Task TriggerCompileAsync()


### PR DESCRIPTION
Closes #127

Adds a link to the playground status bar showing which commit is currently deployed, alongside the existing `.net` and `mudblazor` version links.

```
.net 10.0.10   mudblazor v9.7.0   trymudblazor 7b86a90
```

<img width="2560" height="96" alt="image" src="https://github.com/user-attachments/assets/e644085e-db2f-440c-98f9-5e38f2a9be3a" />

The short SHA links to the corresponding GitHub commit.

No versioning package needed. The .NET SDK ships Source Link built in, and it already stamps the commit SHA into the assembly:

```
[assembly: AssemblyInformationalVersionAttribute("1.0.0+7b86a90200d8fe74962f4aa410dc333259c6f8e3")]
```

So this just reads that attribute back at runtime. Zero new dependencies, zero csproj changes, and — importantly — zero CI changes, which matters because both workflows delegate to the shared `MudBlazor/Workflows` templates and cant easily have build steps injected.

`Nerdbank.GitVersioning` (suggested in the issue) would also work, but it needs full git history (`fetch-depth: 0`), which would mean a PR against the shared workflow repo. It buys auto-incrementing semver, which isnt what this issue is asking for.