### PR TITLE
Triage new issues with AutoTriage

### DIFF
--- a/.github/workflows/autotriage.yml
+++ b/.github/workflows/autotriage.yml
@@ -1,0 +1,24 @@
+name: AutoTriage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage:
+    if: ${{ github.repository_owner == 'MudBlazor' && github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: danielchalmers/AutoTriage@v4
+        with:
+          issues: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Runs the same AutoTriage action as `MudBlazor/MudBlazor`, on newly opened issues only.

**Why:** 12 of 14 open issues are over a year old, and #200 — "try.mudblazor.com not loading because of corrupted .js file" — has been open since 2026-05-26. A two-month-old outage report on a public property is the failure mode of a repo nobody watches.

**Issues only**, no `pull_request_target` — 18 PRs in 180 days, **zero from external contributors** (12 bots, 6 core team), so it would fire almost entirely on bot PRs.

Guards: `repository_owner == 'MudBlazor'` (skips forks) and `sender.type != 'Bot'` — the latter matters here specifically, since #204 is a Renovate "Dependency Dashboard" issue. `GEMINI_API_KEY` is already an org secret, so no setup needed.

No `AutoTriage.prompt` — the action falls back to its default policy. Uses `checkout@v7` rather than the `@v4` elsewhere here. Add `dry-run: "true"` to review the plan before it acts.

Note this covers **newly opened** issues only; the 12 year-old ones need a scheduled backlog sweep.

_Replaces #212, which became unreopenable after a bad force-push._
