### PR TITLE
Replace archived Blazored.LocalStorage with direct JS interop

### DIFF
--- a/src/TryMudBlazor.Client/Program.cs
+++ b/src/TryMudBlazor.Client/Program.cs
@@ -5,7 +5,6 @@ namespace TryMudBlazor.Client
     using System.Net.Http;
     using System.Reflection;
     using System.Threading.Tasks;
-    using Blazored.LocalStorage;
     using Microsoft.AspNetCore.Components.Web;
     using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
     using Microsoft.AspNetCore.Components.WebAssembly.Services;
@@ -41,7 +40,6 @@ namespace TryMudBlazor.Client
 
             builder.Logging.Services.AddSingleton<ILoggerProvider, HandleCriticalUserComponentExceptionsLoggerProvider>();
             builder.Services.AddMudServices();
-            builder.Services.AddBlazoredLocalStorage();
             builder.Services.AddScoped<IUserPreferencesService, UserPreferencesService>();
             builder.Services.AddScoped<LayoutService>();
 

--- a/src/TryMudBlazor.Client/Services/UserPreferences/UserPreferencesService.cs
+++ b/src/TryMudBlazor.Client/Services/UserPreferences/UserPreferencesService.cs
@@ -1,7 +1,8 @@
-﻿namespace TryMudBlazor.Client.Services.UserPreferences;
+namespace TryMudBlazor.Client.Services.UserPreferences;
 
+using System.Text.Json;
 using System.Threading.Tasks;
-using Blazored.LocalStorage;
+using Microsoft.JSInterop;
 
 public interface IUserPreferencesService
 {
@@ -20,21 +21,38 @@ public interface IUserPreferencesService
 
 public class UserPreferencesService : IUserPreferencesService
 {
-    private readonly ILocalStorageService _localStorage;
+    private readonly IJSRuntime _jsRuntime;
     private const string Key = "userPreferences";
 
-    public UserPreferencesService(ILocalStorageService localStorage)
+    public UserPreferencesService(IJSRuntime jsRuntime)
     {
-        _localStorage = localStorage;
+        _jsRuntime = jsRuntime;
     }
 
     public async Task SaveUserPreferences(UserPreferences userPreferences)
     {
-        await _localStorage.SetItemAsync(Key, userPreferences);
+        // Default serializer options keep the PascalCase property names that editor/main.js reads directly.
+        var json = JsonSerializer.Serialize(userPreferences);
+
+        await _jsRuntime.InvokeVoidAsync("localStorage.setItem", Key, json);
     }
 
     public async Task<UserPreferences> LoadUserPreferences()
     {
-        return await _localStorage.GetItemAsync<UserPreferences>(Key);
+        var json = await _jsRuntime.InvokeAsync<string>("localStorage.getItem", Key);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<UserPreferences>(json);
+        }
+        catch (JsonException)
+        {
+            // Ignore preferences that can no longer be read and fall back to the defaults.
+            return null;
+        }
     }
 }

--- a/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
+++ b/src/TryMudBlazor.Client/TryMudBlazor.Client.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" />


### PR DESCRIPTION
The [Blazored organization archived all of its repositories](https://github.com/orgs/Blazored/repositories) on 2025-12-26, [`Blazored/LocalStorage`](https://github.com/Blazored/LocalStorage) among them. The package still works, but it is frozen: no .NET version fixes, no security fixes, and dependency scanners will keep flagging it.

`UserPreferencesService` was the only consumer, and it used exactly two calls (`SetItemAsync`/`GetItemAsync`) against a single key. That is less code than the dependency costs, so it is now done with `IJSRuntime` and `System.Text.Json` directly, and the `PackageReference` plus `AddBlazoredLocalStorage()` registration are gone.

Two compatibility constraints, both preserved:

- **Stored payload format.** Blazored serializes objects with a default `JsonSerializerOptions` (its only added converter is for `TimeSpan`, which `UserPreferences` doesn't use). Keeping the default options means the written JSON is byte-identical, so preferences already in users' browsers keep loading — no migration.
- **`editor/main.js`.** It reads `localStorage.getItem("userPreferences")` directly and looks up the PascalCase `DarkTheme` property, so the serializer must not switch to camelCase. Left on the defaults deliberately, with a comment saying why.

Unreadable JSON now falls back to defaults instead of throwing, which is what Blazored effectively did.