### PR TITLE
Remove `Microsoft.DotNet.Arcade.Sdk` dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,8 +31,7 @@
       "matchManagers": ["nuget"],
       "matchPackageNames": [
         "Microsoft.CodeAnalysis.*",
-        "Microsoft.Net.Compilers.Razor.Toolset",
-        "Microsoft.DotNet.Arcade.Sdk"
+        "Microsoft.Net.Compilers.Razor.Toolset"
       ],
       "groupName": "Razor compiler toolchain",
       "dependencyDashboardApproval": true

--- a/src/Try.Core/Try.Core.csproj
+++ b/src/Try.Core/Try.Core.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>Microsoft.CodeAnalysis.Razor.Test</AssemblyName>
-    <KeyOriginatorFile>$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\snk\AspNetCore.snk</KeyOriginatorFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -14,7 +12,6 @@
     <PackageReference Include="MudBlazor" Version="*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0-2.24555.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.13.0-2.24555.1" />
-    <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24372.7" PrivateAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Net.Compilers.Razor.Toolset" Version="9.0.0-preview.24555.4" PrivateAssets="all" IncludeAssets="none" GeneratePathProperty="true" />
   </ItemGroup>
   

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -4,7 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Removes `Microsoft.DotNet.Arcade.Sdk` from `Try.Core`, along with the assembly-identity trick it existed to support.

- `src/Try.Core/Try.Core.csproj` — drops the Arcade `PackageReference`, the `AssemblyName` override, and `KeyOriginatorFile`.
- `src/nuget.config` — drops the `dotnet-eng` feed.
- `.github/renovate.json` — drops `Microsoft.DotNet.Arcade.Sdk` from the "Razor compiler toolchain" group.

Arcade was never used as a build SDK here. It was referenced with `IncludeAssets="none"` purely as a carrier for a single 596-byte file, `tools/snk/AspNetCore.snk`, which `KeyOriginatorFile` pointed at.

That, plus renaming the assembly to `Microsoft.CodeAnalysis.Razor.Test`, made `Try.Core` impersonate a Razor test assembly in order to satisfy this declaration inside `Microsoft.CodeAnalysis.Razor.Compiler.dll`:

```
[InternalsVisibleTo("Microsoft.CodeAnalysis.Razor.Test", PublicKey=0024...f33a2904...)]
```

Both lines came in with #157, the PR that deleted the checked-in `libs/*.dll` files and started referencing the Razor compiler out of `Microsoft.Net.Compilers.Razor.Toolset`, following the pattern suggested in dotnet/razor#9494.

The internals access is not actually needed. Every Razor type the code touches is `public` in that assembly — `RazorProjectEngine`, `RazorConfiguration`, `RazorProjectFileSystem`, `RazorProjectItem`, `RazorCodeDocument`, `RazorLanguageVersion`, `RazorExtension`, `CompilerFeatures`. Rebuilding the #157-era tree with the hack stripped out also compiles clean, so it does not appear to have ever been load-bearing in this repo.

Net effect: one fewer prerelease Azure DevOps feed, and a 13.8 MB package no longer downloaded to deliver a 596-byte key.